### PR TITLE
Support errors for nested fieldlists

### DIFF
--- a/govuk_frontend_wtf/main.py
+++ b/govuk_frontend_wtf/main.py
@@ -25,17 +25,38 @@ def wtforms_errors(form, params={}):
     return merger.merge(wtforms_params, params)
 
 
-def flatten_errors(errors, prefix=""):
+# def flatten_errors(errors, prefix=""):
+#     error_list = []
+
+#     for key, value in errors.items():
+#         if isinstance(value, dict):
+#             # Recurse to handle subforms
+#             error_list += flatten_errors(value, prefix=prefix + key + "-")
+#         else:
+#             error_list.append({"text": value[0], "href": "#{}{}".format(prefix, key)})
+#     return error_list
+
+
+def flatten_errors(errors, prefix=''):
+    """Return list of errors from form errors."""
     error_list = []
-
-    for key, value in errors.items():
-
-        if isinstance(value, dict):
-            # Recurse to handle subforms
-            error_list += flatten_errors(value, prefix=prefix + key + "-")
-        else:
-            error_list.append({"text": value[0], "href": "#{}{}".format(prefix, key)})
-
+    if isinstance(errors, dict):
+        for key, value in errors.items():
+            # Recurse to handle subforms.
+            error_list += flatten_errors(value, prefix=f'{prefix}{key}-')
+    elif isinstance(errors, list) and isinstance(errors[0], dict):
+        for idx, error in enumerate(errors):
+            error_list += flatten_errors(error, prefix=f'{prefix}{idx}-')
+    elif isinstance(errors, list):
+        error_list.append({
+            'text': errors[0],
+            'href': f'#{prefix}error'
+        })
+    else:
+        error_list.append({
+            'text': errors,
+            'href': f'#{prefix}error'
+        })
     return error_list
 
 

--- a/govuk_frontend_wtf/main.py
+++ b/govuk_frontend_wtf/main.py
@@ -25,18 +25,6 @@ def wtforms_errors(form, params={}):
     return merger.merge(wtforms_params, params)
 
 
-# def flatten_errors(errors, prefix=""):
-#     error_list = []
-
-#     for key, value in errors.items():
-#         if isinstance(value, dict):
-#             # Recurse to handle subforms
-#             error_list += flatten_errors(value, prefix=prefix + key + "-")
-#         else:
-#             error_list.append({"text": value[0], "href": "#{}{}".format(prefix, key)})
-#     return error_list
-
-
 def flatten_errors(errors, prefix=''):
     """Return list of errors from form errors."""
     error_list = []
@@ -50,12 +38,12 @@ def flatten_errors(errors, prefix=''):
     elif isinstance(errors, list):
         error_list.append({
             'text': errors[0],
-            'href': f'#{prefix}error'
+            'href': '#{}'.format(prefix.rstrip('-'))
         })
     else:
         error_list.append({
             'text': errors,
-            'href': f'#{prefix}error'
+            'href': '#{}'.format(prefix.rstrip('-'))
         })
     return error_list
 

--- a/tests/fixtures/wtf_widgets_data.yaml
+++ b/tests/fixtures/wtf_widgets_data.yaml
@@ -522,6 +522,27 @@ TestMultipleFileField:
       not_expected_output:
         - <script>alert("Hello")</script>
 
+TestNestedForm:
+  template: "{{ form['nested_form'] }}"
+  tests:
+    test_empty_get:
+      expected_output:
+        - <div class="govuk-form-group">
+        - <label for="nested_form-0">Nested Form-0</label>
+        - <input class="govuk-input" id="nested_form-0-string_field" name="nested_form-0-string_field" type="text" required="required">
+    test_output_sanitized:
+      request:
+        method: post
+        data:
+          nested_form-0-string_field: <script>alert("Hello")</script>
+      expected_output:
+        - <label for="nested_form-0">Nested Form-0</label>
+        - <label for="nested_form-0-string_field">StringField</label>
+        - <input class="govuk-input" id="nested_form-0-string_field" name="nested_form-0-string_field" type="text"
+        - required="required">
+      not_expected_output:
+        - <script>alert("Hello")</script>
+
 TestSubmitButton:
   template: "{{ form['submit_button'] }}"
   tests:
@@ -608,6 +629,7 @@ TestErrorSummary:
         method: post
         data:
           string_field: John Smith
+          nested_form-0-string_field: John Smith
           date_field:
             - 1
             - 1

--- a/tests/fixtures/wtf_widgets_example_form.py
+++ b/tests/fixtures/wtf_widgets_example_form.py
@@ -11,12 +11,15 @@ from govuk_frontend_wtf.wtforms_widgets import (
     GovTextArea,
     GovTextInput,
 )
+from wtforms import Form as NoCsrfForm
 from wtforms.fields import (
     BooleanField,
     DateField,
     DecimalField,
+    FieldList,
     FileField,
     FloatField,
+    FormField,
     IntegerField,
     MultipleFileField,
     PasswordField,
@@ -28,6 +31,14 @@ from wtforms.fields import (
     TextAreaField,
 )
 from wtforms.validators import Email, EqualTo, InputRequired, ValidationError
+
+
+class ExampleChildForm(NoCsrfForm):
+    string_field = StringField(
+        'StringField',
+        widget=GovTextInput(),
+        validators=[InputRequired(message="StringField is required")],
+    )
 
 
 class ExampleForm(FlaskForm):
@@ -135,6 +146,11 @@ class ExampleForm(FlaskForm):
         "Re-type your password",
         widget=GovPasswordInput(),
         validators=[InputRequired("Please retype your password")],
+    )
+
+    nested_form = FieldList(
+        FormField(ExampleChildForm),
+        min_entries=1,
     )
 
     submit_button = SubmitField("SubmitField", widget=GovSubmitInput())


### PR DESCRIPTION
Extend `flatten_errors` to support flattening errors from FieldList/FormField for display in the error summary.