### PR TITLE
Ensure day, month, year values are set when default provided for GovDateInput

### DIFF
--- a/govuk_frontend_wtf/wtforms_widgets.py
+++ b/govuk_frontend_wtf/wtforms_widgets.py
@@ -139,9 +139,8 @@ class GovDateInput(GovFormBase):
 
     def map_gov_params(self, field, **kwargs):
         params = super().map_gov_params(field, **kwargs)
-        day, month, year = [None] * 3
-        if field.raw_data is not None:
-            day, month, year = field.raw_data
+        if field._value():
+            day, month, year = field._value().split(' ')
         params.setdefault('fieldset', {
             'legend': {
                 'text': field.label.text,

--- a/tests/fixtures/wtf_widgets_data.yaml
+++ b/tests/fixtures/wtf_widgets_data.yaml
@@ -40,11 +40,11 @@ TestDateField:
       test_empty_get:
         expected_output:
           - <label class="govuk-label govuk-date-input__label" for="date_field-day">\s*Day\s*</label>
-          - <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date_field-day" name="date_field" type="text" pattern="\[0-9\]\*" inputmode="numeric">
+          - <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date_field-day" name="date_field" type="text" value="23" pattern="\[0-9\]\*" inputmode="numeric">
           - <label class="govuk-label govuk-date-input__label" for="date_field-month">\s*Month\s*</label>
-          - <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date_field-month" name="date_field" type="text" pattern="\[0-9\]\*" inputmode="numeric">
+          - <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date_field-month" name="date_field" type="text" value="11" pattern="\[0-9\]\*" inputmode="numeric">
           - <label class="govuk-label govuk-date-input__label" for="date_field-year">\s*Year\s*</label>
-          - <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date_field-year" name="date_field" type="text" pattern="\[0-9\]\*" inputmode="numeric">
+          - <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date_field-year" name="date_field" type="text" value="2020" pattern="\[0-9\]\*" inputmode="numeric">
       test_valid_post:
           request:
               method: post

--- a/tests/fixtures/wtf_widgets_example_form.py
+++ b/tests/fixtures/wtf_widgets_example_form.py
@@ -1,3 +1,5 @@
+import datetime
+
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import (
     GovCheckboxesInput,
@@ -50,6 +52,7 @@ class ExampleForm(FlaskForm):
 
     date_field = DateField(
         "DateField",
+        default=datetime.datetime.fromisoformat('2020-11-23T00:00:00'),
         format="%d %m %Y",
         widget=GovDateInput(),
         validators=[InputRequired(message="Date is required")]

--- a/tests/fixtures/wtf_widgets_example_form.py
+++ b/tests/fixtures/wtf_widgets_example_form.py
@@ -52,7 +52,7 @@ class ExampleForm(FlaskForm):
 
     date_field = DateField(
         "DateField",
-        default=datetime.datetime.fromisoformat('2020-11-23T00:00:00'),
+        default=datetime.datetime(day=23, month=11, year=2020),
         format="%d %m %Y",
         widget=GovDateInput(),
         validators=[InputRequired(message="Date is required")]


### PR DESCRIPTION
I removed this segment because should the field fail to validate they still contain a value - i.e. this isn't necessary for that behaviour.
```
        if field.raw_data is not None:
            day, month, year = field.raw_data
```