### PR TITLE
Improve handling of invalid `GovDateInput` data

### DIFF
--- a/govuk_frontend_wtf/wtforms_widgets.py
+++ b/govuk_frontend_wtf/wtforms_widgets.py
@@ -158,8 +158,11 @@ class GovDateInput(GovFormBase):
     def map_gov_params(self, field, **kwargs):
         params = super().map_gov_params(field, **kwargs)
         day, month, year = [None] * 3
-        if field._value():
-            day, month, year = field._value().split(" ")
+        if field.raw_data is not None:
+            day, month, year = field.raw_data
+        elif field.data:
+            day, month, year = field.data.strftime("%d %m %Y").split(" ")
+
         params.setdefault(
             "fieldset",
             {

--- a/tests/fixtures/wtf_widgets_data.yaml
+++ b/tests/fixtures/wtf_widgets_data.yaml
@@ -82,6 +82,22 @@ TestDateField:
               - <label class="govuk-label govuk-date-input__label" for="date_field-year">\s*Year\s*</label>
               - <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" id="date_field-year" name="date_field" type="text" value="C" pattern="\[0-9\]\*" inputmode="numeric">
               - <div id="date_field-hint" class="govuk-hint">\s*DateFieldHint\s*</div>
+          request:
+              method: post
+              data:
+                  date_field:
+                    - 1
+                    - " "  # Month value contains only whitespace
+                    - 2020
+          expected_output:
+              - <div class="govuk-form-group govuk-form-group--error">
+              - <label class="govuk-label govuk-date-input__label" for="date_field-day">\s*Day\s*</label>
+              - <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="date_field-day" name="date_field" type="text" value="1" pattern="\[0-9\]\*" inputmode="numeric">
+              - <label class="govuk-label govuk-date-input__label" for="date_field-month">\s*Month\s*</label>
+              - <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="date_field-month" name="date_field" type="text" value=" " pattern="\[0-9\]\*" inputmode="numeric">
+              - <label class="govuk-label govuk-date-input__label" for="date_field-year">\s*Year\s*</label>
+              - <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" id="date_field-year" name="date_field" type="text" value="2020" pattern="\[0-9\]\*" inputmode="numeric">
+              - <div id="date_field-hint" class="govuk-hint">\s*DateFieldHint\s*</div>
 
 TestDateFieldDefault:
   template: "{{ form.date_field_default }}"


### PR DESCRIPTION
This PR:
- removes `ValueError` when parsing edge-case `GovDateInput` input data - see below
- removes call to a private WTForm `Field` method. 
- ensures user-inputted data (i.e. `Field.raw_data`) always takes precedence over default values (i.e. `Field.data`)

**Resolution of edge cases:**
Data inputted with spaces in either the day, month or year field (e.g. `01`, ` `, `2021`) causes the following exception:
`day, month, year = field._value().split(\" \")\n", "ValueError: too many values to unpack (expected 3)\n"]}`