### PR TITLE
Correct empty hint for RadioField and test earlier fix for StringField

### DIFF
--- a/govuk_frontend_wtf/gov_form_base.py
+++ b/govuk_frontend_wtf/gov_form_base.py
@@ -106,7 +106,7 @@ class GovIterableBase(GovFormBase):
         params = {
             "name": field.name,
             "items": kwargs["items"],
-            "hint": {"text": field.description},
+            "hint": {"text": field.description} if field.description else None,
         }
 
         # Merge in any extra params passed in from the template layer

--- a/tests/fixtures/wtf_widgets_data.yaml
+++ b/tests/fixtures/wtf_widgets_data.yaml
@@ -75,6 +75,16 @@ TestStringFieldId:
         - <div class="govuk-form-group govuk-form-group--error">
         - <div id="custom-id-hint" class="govuk-hint">\s*StringFieldHint\s*</div>
 
+TestStringFieldNoDescription:
+  template: "{{ form.string_field_no_description }}"
+  tests:
+    test_empty_description:
+      expected_output:
+        - <input class="govuk-input" id="string_field_no_description" name="string_field_no_description" type="text" required="required">
+        - <label class="govuk-label" for="string_field_no_description">\s*StringField\s*</label>
+      not_expected_output:
+        - <div id="string_field_no_description-hint" class="govuk-hint">\s*</div>
+
 TestDateField:
   template: "{{ form.date_field }}"
   tests:
@@ -806,6 +816,7 @@ TestErrorSummary:
         data:
           string_field: John Smith
           string_field_id: John Smith
+          string_field_no_description: John Smith
           nested_form-0-string_field: John Smith
           date_field:
             - 1
@@ -841,6 +852,7 @@ TestErrorSummary:
         data:
           string_field: Andy
           string_field_id: Andy
+          string_field_no_description: Andy
           date_field:
             - 1
             - 1

--- a/tests/fixtures/wtf_widgets_data.yaml
+++ b/tests/fixtures/wtf_widgets_data.yaml
@@ -623,23 +623,23 @@ TestRadioField:
         - <input class="govuk-radios__input" id="radio_field-3" name="radio_field" type="radio" value="three">
         - <label class="govuk-label govuk-radios__label" for="radio_field-3">\s*Three\s*</label>
         - <div id="radio_field-hint" class="govuk-hint">\s*RadioFieldHint\s*</div>
+
+TestRadioFieldNoDescription:
+  template: "{{ form.radio_field_no_description }}"
+  tests:
     test_empty_description:
-      request:
-        method: get
-        data:
-          radio_field_no_description: foo
       expected_output:
         - <div class="govuk-form-group">
         - <div class="govuk-radios" data-module="govuk-radios">
         - <div class="govuk-radios__item">
-        - <input class="govuk-radios__input" id="radio_field" name="radio_field" type="radio" value="one">
-        - <label class="govuk-label govuk-radios__label" for="radio_field">\s*One\s*</label>
-        - <input class="govuk-radios__input" id="radio_field-2" name="radio_field" type="radio" value="two">
-        - label class="govuk-label govuk-radios__label" for="radio_field-2">\s*Two\s*</label>
-        - <input class="govuk-radios__input" id="radio_field-3" name="radio_field" type="radio" value="three">
-        - <label class="govuk-label govuk-radios__label" for="radio_field-3">\s*Three\s*</label>
+        - <input class="govuk-radios__input" id="radio_field_no_description" name="radio_field_no_description" type="radio" value="one">
+        - <label class="govuk-label govuk-radios__label" for="radio_field_no_description">\s*One\s*</label>
+        - <input class="govuk-radios__input" id="radio_field_no_description-2" name="radio_field_no_description" type="radio" value="two">
+        - <label class="govuk-label govuk-radios__label" for="radio_field_no_description-2">\s*Two\s*</label>
+        - <input class="govuk-radios__input" id="radio_field_no_description-3" name="radio_field_no_description" type="radio" value="three">
+        - <label class="govuk-label govuk-radios__label" for="radio_field_no_description-3">\s*Three\s*</label>
       not_expected_output:
-        - <div id="radio_field-hint" class="govuk-hint"></div>
+        - <div id="radio_field_no_description-hint" class="govuk-hint">\s*</div>
 
 TestFileField:
   template: "{{ form.file_field }}"

--- a/tests/fixtures/wtf_widgets_example_form.py
+++ b/tests/fixtures/wtf_widgets_example_form.py
@@ -62,6 +62,12 @@ class ExampleForm(FlaskForm):
         description="StringFieldHint",
     )
 
+    string_field_no_description = StringField(
+        "StringField",
+        widget=GovTextInput(),
+        validators=[InputRequired(message="StringField is required")],
+    )
+
     date_field = DateField(
         "DateField",
         format="%d %m %Y",


### PR DESCRIPTION
The fix for #43 targetted `GovFormBase` subclasses when the intention was to fix `RadioField`, which is a subclass of `GovIterableBase`. The associated test also failed to assert this functionality.

This PR corrects the test for `RadioField` and fixes it in `GovIterableBase`. It also adds a test to ensure `GovFormBase` subclasses, such as `StringField`, don't produce a hint when the field has no description, which was inadvertently fixed in #43.